### PR TITLE
Performance updates that don't restructure the code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim
 
 WORKDIR /app
-COPY parsedmarc/ parsedmarc/
+COPY src/ src/
 COPY README.md pyproject.toml ./
 
 RUN pip install -U pip

--- a/src/parsedmarc/cli.py
+++ b/src/parsedmarc/cli.py
@@ -1011,6 +1011,7 @@ def _main():
                 ip_db_path=opts.ip_db_path,
                 offline=opts.offline,
                 nameservers=opts.nameservers,
+                dns_timeout=opts.dns_timeout,
                 test=opts.mailbox_test,
                 strip_attachment_payloads=opts.strip_attachment_payloads,
             )

--- a/src/parsedmarc/utils.py
+++ b/src/parsedmarc/utils.py
@@ -340,7 +340,9 @@ def get_ip_address_info(
     if offline:
         reverse_dns = None
     else:
-        reverse_dns = get_reverse_dns(ip_address, cache=cache, nameservers=nameservers, timeout=timeout)
+        reverse_dns = get_reverse_dns(
+            ip_address, cache=cache, nameservers=nameservers, timeout=timeout
+        )
     country = get_ip_address_country(ip_address, db_path=ip_db_path)
     info["country"] = country
     info["reverse_dns"] = reverse_dns

--- a/src/parsedmarc/utils.py
+++ b/src/parsedmarc/utils.py
@@ -121,7 +121,7 @@ def query_dns(
     domain = str(domain).lower()
     record_type = record_type.upper()
     cache_key = f"{domain}_{record_type}"
-    if cache:
+    if cache is not None:
         records = cache.get(cache_key, None)
         if records:
             return records
@@ -158,7 +158,7 @@ def query_dns(
                 resolver.resolve(domain, record_type, lifetime=timeout),
             )
         )
-    if cache:
+    if cache is not None:
         cache[cache_key] = records
 
     return records
@@ -331,7 +331,7 @@ def get_ip_address_info(
 
     """
     ip_address = ip_address.lower()
-    if cache:
+    if cache is not None:
         info = cache.get(ip_address, None)
         if info:
             return info
@@ -340,7 +340,7 @@ def get_ip_address_info(
     if offline:
         reverse_dns = None
     else:
-        reverse_dns = get_reverse_dns(ip_address, nameservers=nameservers, timeout=timeout)
+        reverse_dns = get_reverse_dns(ip_address, cache=cache, nameservers=nameservers, timeout=timeout)
     country = get_ip_address_country(ip_address, db_path=ip_db_path)
     info["country"] = country
     info["reverse_dns"] = reverse_dns


### PR DESCRIPTION
Just a couple of fixes to improve the performance.

The `self._ip_address_cache` was not actually being used.  
- The `get_reverse_dns` call was not passing on the cache parameter that `get_ip_address_info` receives.
- The cache was being considered to be undefined because it was empty, so entries were not being added to make it not empty.

The `dns_timeout` was not being passed all of the way from the options, resulting in 6.0 seconds always being used for mail messages. (I consider setting the timeout to 2.0 seconds to be a performance improvement.)

I also made the update to the `Dockerfile` to work with the new source folder structure.