### PR TITLE
[mypy] Stop ignoring msgraph-sdk-python-core

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,10 +17,6 @@ ignore_missing_imports = True
 # https://github.com/seanthegeek/mailsuite/issues/9
 ignore_missing_imports = True
 
-[mypy-msgraph.core]
-# https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/446
-ignore_missing_imports = True
-
 [mypy-mailparser.*]
 # https://github.com/SpamScope/mail-parser
 ignore_missing_imports = True


### PR DESCRIPTION
Fixed in https://github.com/microsoftgraph/msgraph-sdk-python-core/pull/674

This commit re-applies the commit reverted in 9442a47795bca506bd5c0baa2b772c545eeb047e