### PR TITLE
Fix typing on config classes and test source/sink init

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,128 @@
-# Contributing to parsedmarc
+# Contributing
 
-## Bug reports
+Contributions are welcome!
 
-Please report bugs on the GitHub issue tracker
+## Code of Conduct
 
-<https://github.com/domainaware/parsedmarc/issues>
+In general we follow the [Python Software Foundation Code of Conduct](https://policies.python.org/python.org/code-of-conduct/) (note: we are not affiliated with the PSF).
+
+## Pull Request Process
+
+**0. Before you begin**
+
+If you're not familiar with contributing to open source software, [start by reading this guide](https://opensource.guide/how-to-contribute/).
+
+Be aware that anything you contribute will be licenced under [the project's licence](https://github.com/nhairs/python-json-logger/blob/main/LICENSE). If you are making a change as a part of your job, be aware that your employer might own your work and you'll need their permission in order to licence the code.
+
+### 1. Find something to work on
+
+Where possible it's best to stick to established issues where discussion has already taken place. Contributions that haven't come from a discussed issue are less likely to be accepted. A good place to start is the [`open for work`](https://github.com/nhairs/parsedmarc-fork/issues?q=is%3Aissue+is%3Aopen+label%3A%22open+for+work%22) issue label.
+
+The following are things that can be worked on without an existing issue:
+
+- Updating documentation. This includes fixing in-code documentation / comments, and the overall docs.
+- Small changes that don't change functionality such as refactoring or adding / updating tests.
+
+### 2. Fork the repository and make your changes
+
+We don't have styling documentation, so where possible try to match existing code. This includes the use of "headings" and "dividers" (this will make sense when you look at the code).
+
+All devlopment tooling can be installed (usually into a virtual environment), using the `dev` optional dependency:
+
+```shell
+pip install -e '.[dev]'`
+```
+
+Before creating your pull request you'll want to format your code and run the linters and tests:
+
+```shell
+# Format
+black src tests
+
+# Lint
+pylint --output-format=colorized src
+mypy src tests
+
+# Tests
+pytest
+```
+
+If making changes to the documentation you can preview the changes locally using `mkdocs`. Changes to the README can be previewed using [`grip`](https://github.com/joeyespo/grip) (not included in `dev` dependencies).
+
+```shell
+mkdocs serve
+```
+
+!!! note
+    In general we will always squash merge pull requests so you do not need to worry about a "clean" commit history.
+
+### 3. Checklist
+
+Before pushing and creating your pull request, you should make sure you've done the following:
+
+- Updated any relevant tests.
+- Formatted your code and run the linters and tests.
+- Updated the version number in `pyproject.toml`. In general using a `.devN` suffix is acceptable.
+  This is not required for changes that do no affect the code such as documentation.
+- Add details of the changes to the change log (`docs/change-log.md`), creating a new section if needed.
+- Add notes for new / changed features in the relevant docstring.
+
+**4. Create your pull request**
+
+When creating your pull request be aware that the title and description will be used for the final commit so pay attention to them.
+
+Your pull request description should include the following:
+
+- Why the pull request is being made
+- Summary of changes
+- How the pull request was tested - especially if not covered by unit testing.
+
+Once you've submitted your pull request make sure that all CI jobs are passing. Pull requests with failing jobs will not be reviewed.
+
+### 5. Code review
+
+Your code will be reviewed by a maintainer.
+
+If you're not familiar with code review start by reading [this guide](https://google.github.io/eng-practices/review/).
+
+!!! tip "Remember you are not your work"
+
+    You might be asked to explain or justify your choices. This is not a criticism of your value as a person!
+
+    Often this is because there are multiple ways to solve the same problem and the reviewer would like to understand more about the way you solved.
+
+## Common Topics
+
+### Adding a Source or Sink
+
+New sources and sinks are welcome, how popular / common a service is will be taken into consideration before being added. You should open an issue before creating a pull request.
+
+#### Common Tasks
+
+When adding a new source or sink you will need to pay attention to the following:
+
+- Ensure that the class and the config class have appropriate docstrings.
+- Update / create the relevant source / sink documention.
+- Update `tests/test_source_sink_config` to ensure basic intialisation.
+
+### Versioning and breaking compatability
+
+This project uses semantic versioning.
+
+In general backwards compatability is always preferred. This library is widely used and not particularly sophisticated and as such there must be a good reason for breaking changes.
+
+Feature changes MUST be compatible with all [security supported versions of Python](https://endoflife.date/python) and SHOULD be compatible with all unsupported versions of Python where [recent downloads over the last 90 days exceeds 5% of all downloads](https://pypistats.org/packages/parsedmarc).
+
+In general, only the latest `major.minor` version of ParseDMARC is supported. Bug fixes and feature backports requiring a version branch may be considered but must be discussed with the maintainers first.
+
+See also [Security Policy](security.md).
+
+### Spelling
+
+The original implementation of this project used US spelling so it will continue to use US spelling for all code.
+
+Documentation is more flexible and may use a variety of English spellings.
+
+### Contacting the Maintainers
+
+In general it is preferred to keep communication to GitHub, e.g. through comments on issues and pull requests. If you do need to contact the maintainers privately, please do so using the email addresses in the maintainers section of the `pyproject.toml`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,6 +101,9 @@ New sources and sinks are welcome, how popular / common a service is will be tak
 
 When adding a new source or sink you will need to pay attention to the following:
 
+- Ensure that all type annotations on `Source`, `Sink`, and their config classes are Python 3.8 compatible as these are inspected during runtime.
+  - For example this means using `List[str]` instead of `list[str]` and `Union[str, int, None]` instead of `str | int | None`.
+  - For all other annotations using the latest styles is okay.
 - Ensure that the class and the config class have appropriate docstrings.
 - Update / create the relevant source / sink documention.
 - Update `tests/test_source_sink_config` to ensure basic intialisation.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security support for Python JSON Logger is provided for all [security supported versions of Python](https://endoflife.date/python) and for unsupported versions of Python where [recent downloads over the last 90 days exceeds 5% of all downloads](https://pypistats.org/packages/parsedmarc).
+
+
+As of 2024-09-07 security support is provided for Python versions `3.8+`.
+
+
+## Reporting a Vulnerability
+
+Please report vulnerabilties [using GitHub](https://github.com/nhairs/parsedmarc-fork/security/advisories/new).

--- a/src/parsedmarc/sink/elasticsearch.py
+++ b/src/parsedmarc/sink/elasticsearch.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 # Standard Library
-from typing import Any, Literal
+from typing import Any, Dict, Literal
 
 # Local
 from ..const import AppState
@@ -69,5 +69,5 @@ class ElasticsearchConfig(BaseConfig):
     """Elasticsearch Config"""
 
     # As per https://elasticsearch-py.readthedocs.io/en/v8.13.0/api/elasticsearch.html
-    client: dict[str, Any]
+    client: Dict[str, Any]
     on_duplicate: Literal["discard"] = "discard"  # TODO: implement update logic and add

--- a/src/parsedmarc/source/aws.py
+++ b/src/parsedmarc/source/aws.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard Library
 from collections import deque
 from io import BytesIO
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict
 
 # Installed
 import boto3
@@ -170,5 +170,5 @@ class SimpleEmailServiceConfig(BaseConfig):
     *New in 9.0*.
     """
 
-    session: dict[str, Any] = Field(default_factory=dict)
+    session: Dict[str, Any] = Field(default_factory=dict)
     queue_name: str

--- a/src/parsedmarc/source/email.py
+++ b/src/parsedmarc/source/email.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard Library
 from collections import deque
 import time
-from typing import Literal
+from typing import List, Literal, Union
 
 # Local
 from .. import mail
@@ -154,7 +154,7 @@ class ImapConfig(MailboxConfig):
     host: str  # IMAP host to connect to
     username: str  # IMAP Username
     password: str  # IMAP Password
-    port: int | None = (
+    port: Union[int, None] = (
         None  # Port to connect to, if `None` will use the default IMAP port based on the SSL/TLS settings
     )
     ssl: bool = True  # Use SSL/TLS
@@ -202,7 +202,7 @@ class GoogleConfig(MailboxConfig):
 
     credentials_file: str  # Path to file containing the credentials
     token_file: str = ".google_token"  # Path to save the token file
-    scopes: list[str] = [
+    scopes: List[str] = [
         "https://www.googleapis.com/auth/gmail.modify"
     ]  # Scopes to use when acquiring credentials
     include_spam_trash: bool = (
@@ -266,9 +266,9 @@ class MicrosoftGraphConfig(MailboxConfig):
     auth_method: Literal["UsernamePassword", "DeviceCode", "ClientSecret"] = "UsernamePassword"
     client_id: str
     client_secret: str
-    username: str | None = None
-    password: str | None = None
-    tenant_id: str | None = None
-    mailbox: str | None = None
+    username: Union[str, None] = None
+    password: Union[str, None] = None
+    tenant_id: Union[str, None] = None
+    mailbox: Union[str, None] = None
     token_file: str = ".microsoft_graph_token"
     allow_unencrypted_storage: bool = False

--- a/src/parsedmarc/source/file.py
+++ b/src/parsedmarc/source/file.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard Library
 from collections import deque
 import pathlib
-from typing import List, Literal
+from typing import Dict, List, Literal
 
 # Local
 from ..const import AppState
@@ -34,7 +34,7 @@ class DirectoriesAndFiles(Source):
 
     config: DirectoriesAndFilesConfig
 
-    _EXT: dict[str, Literal["email", "mbox"]] = {
+    _EXT: Dict[str, Literal["email", "mbox"]] = {
         ".eml": "email",
         ".msg": "email",
         ".mbox": "mbox",

--- a/src/parsedmarc/source/file.py
+++ b/src/parsedmarc/source/file.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard Library
 from collections import deque
 import pathlib
-from typing import Literal
+from typing import List, Literal
 
 # Local
 from ..const import AppState
@@ -122,7 +122,7 @@ class DirectoriesAndFilesConfig(BaseConfig):
     *New in 9.0*.
     """
 
-    paths: list[str]
+    paths: List[str]
 
 
 ## Watching

--- a/src/parsedmarc/source/util.py
+++ b/src/parsedmarc/source/util.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from copy import deepcopy
 import random
 import time
-from typing import Any
+from typing import Any, Dict, Union
 import uuid
 
 # Local
@@ -64,9 +64,9 @@ class UtilityConfig(BaseConfig):
     """
 
     sleep_enabled: bool = True
-    sleep_time: int | None = None
-    sleep_min: int | float = 0.2
-    sleep_max: int | float = 1.5
+    sleep_time: Union[int, None] = None
+    sleep_min: Union[int, float] = 0.2
+    sleep_max: Union[int, float] = 1.5
 
 
 class ReportConfig(UtilityConfig):
@@ -75,7 +75,7 @@ class ReportConfig(UtilityConfig):
     *New in 9.0*.
     """
 
-    report: dict[str, Any] | None = None
+    report: Union[Dict[str, Any], None] = None
 
 
 ## DMARC Reports

--- a/tests/test_source_sink_config.py
+++ b/tests/test_source_sink_config.py
@@ -1,0 +1,107 @@
+### IMPORTS
+### ============================================================================
+# Future
+from __future__ import annotations
+
+# Standard Library
+from typing import Any, Dict, Type
+
+# Installed
+import pytest
+
+# Package
+from parsedmarc.parser import ReportParser
+from parsedmarc.sink.base import Sink
+import parsedmarc.sink.elasticsearch
+import parsedmarc.sink.util
+import parsedmarc.source.aws
+from parsedmarc.source.base import Source
+import parsedmarc.source.email
+import parsedmarc.source.file
+import parsedmarc.source.util
+
+### SETUP
+### ============================================================================
+PARSER = ReportParser()
+
+
+### TESTS
+### ============================================================================
+@pytest.mark.parametrize(
+    "class_, config",
+    [
+        # AWS
+        (parsedmarc.source.aws.SimpleEmailService, {"queue_name": "foo"}),
+        (
+            parsedmarc.source.aws.SimpleEmailService,
+            {
+                "queue_name": "foo",
+                "session": {"region_name": "ap-southeast-2"},
+            },
+        ),
+        # Email
+        (
+            parsedmarc.source.email.Imap,
+            {"host": "example.org", "username": "nicholas", "password": "secret"},
+        ),
+        (parsedmarc.source.email.Google, {"credentials_file": "/home/user/.parsedmarc"}),
+        (
+            parsedmarc.source.email.MicrosoftGraph,
+            {
+                "auth_method": "UsernamePassword",
+                "client_id": "1234asdf",
+                "client_secret": "secret",
+                "username": "nicholas",
+                "password": "secret",
+            },
+        ),
+        (
+            parsedmarc.source.email.MicrosoftGraph,
+            {
+                "auth_method": "DeviceCode",
+                "client_id": "1234asdf",
+                "client_secret": "secret",
+                "tenant_id": "1234asdf",
+            },
+        ),
+        (
+            parsedmarc.source.email.MicrosoftGraph,
+            {
+                "auth_method": "ClientSecret",
+                "client_id": "1234asdf",
+                "client_secret": "secret",
+                "tenant_id": "1234asdf",
+            },
+        ),
+        # File
+        (
+            parsedmarc.source.file.DirectoriesAndFiles,
+            {"paths": ["/tmp/parsedmarc.d", "/tmp/parsedmarc_reports/report.eml", "./"]},
+        ),
+        # Util
+        (parsedmarc.source.util.StaticAggregateReportGenerator, {"report": {"foo": "bar"}}),
+        (parsedmarc.source.util.RandomAggregateReportGenerator, {}),
+        (parsedmarc.source.util.MalformedAggregateReportGenerator, {}),
+        (parsedmarc.source.util.StaticForensicReportGenerator, {"report": {"foo": "bar"}}),
+        (parsedmarc.source.util.RandomForensicReportGenerator, {}),
+        (parsedmarc.source.util.MalformedForensicReportGenerator, {}),
+    ],
+)
+def test_source_init(class_: Type[Source], config: Dict[str, Any]):
+    source = class_("test", PARSER, config)
+    return
+
+
+@pytest.mark.parametrize(
+    "class_, config",
+    [
+        # ElasticSearch
+        (parsedmarc.sink.elasticsearch.Elasticsearch, {"client": {"foo": "bar"}}),
+        # Util
+        (parsedmarc.sink.util.Noop, {}),
+        (parsedmarc.sink.util.Console, {}),
+    ],
+)
+def test_sink_init(class_: Type[Sink], config: Dict[str, Any]):
+    sink = class_("test", config)
+    return

--- a/tests/test_source_sink_config.py
+++ b/tests/test_source_sink_config.py
@@ -88,7 +88,7 @@ PARSER = ReportParser()
     ],
 )
 def test_source_init(class_: Type[Source], config: Dict[str, Any]):
-    source = class_("test", PARSER, config)
+    class_("test", PARSER, config)
     return
 
 
@@ -103,5 +103,5 @@ def test_source_init(class_: Type[Source], config: Dict[str, Any]):
     ],
 )
 def test_sink_init(class_: Type[Sink], config: Dict[str, Any]):
-    sink = class_("test", config)
+    class_("test", config)
     return


### PR DESCRIPTION
This fixes the type hints on source / sink config classes to ensure that they can be used by all supported versions of python (3.8+).

This also includes adding information to the contribution guidelines on how to add a source / sink.

Because the contributing and security docs were missing they've been added in this diff as well.

### Test Plan

Use new unit tests. 