### PR TITLE
[docs] Add migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # parsedmarc-fork
 
-ParseDMARC-Fork (name TBD) is a tool for collecting, parsing, and storing DMARC reports.
+ParseDMARC is a tool for collecting, parsing, and storing DMARC reports.
 
 ### 🚨 Important 🚨
 
-This repository is a work in progress fork of [domainaware/parsedmarc](https://github.com/domainaware/parsedmarc).
+This repository is an expimental fork of [domainaware/parsedmarc](https://github.com/domainaware/parsedmarc). See [Issue #1](https://github.com/nhairs/parsedmarc-fork/issues/1) for details.
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture
+
+## About parsedmarc-fork
+
+Parsedmarc-fork contains the same functionality of parsedmarc but the main application has been completely rewritten to use a "streaming" model for handling reports. As this required a full rewrite of the main application a number of new internal interfaces have been added to support adding other data sources/destinations with minimal code changes to the main application.
+
+We introduce the following interfaces:
+
+- **Source**: things that produce reports.
+- **Sink**: things that receive reports.
+- **Job**: a container for tracking a report's lifecycle through the application.
+
+At a high level the application operates as follows:
+
+1. Initialise and read configuration
+2. Create and initialise all configured sources and sinks
+3. Create a `SourceWorker` thread for each source.
+  - This worker will get new jobs from the source and send them to a central "inbound" queue.
+4. Create a `SinkWorker` thread for each sink
+  - This worker receives jobs on a queue and passes them to the sink.
+  - The worker then passes the job and it's completion status (success/error) to a central "outbound" queue.
+5. Create an `InboundWorker` thread
+  - This worker takes jobs from the inbound queue and fans out the job to each `SinkWorker`
+6. Create an `OutboundWorker` thread
+  - This worker receives completed jobs then passes the completed job to it's source for acknowledgement.
+  - This allows sources to decide how to handle reports based on status as well as have "in-flight" jobs.
+  - In particular this opens up to new types of works such as those based on queues (e.g. RabbitMQ, AWS SQS).
+  - It also allows us to delay things like archiving/deleting messages until we know they have been stored (email or file based sources).
+7. The main thread does nothing but wait for a shutdown signal. Once received it gracefully shuts down all the works and sends unhandled jobs (i.e. status=cancelled) back to the sources to be handled.
+
+A few other things to note with the application/interfaces are:
+
+- Through the use of [queues](https://docs.python.org/3/library/queue.html) we can limit the number of in-flight jobs ensuring a fairly predictable memory footprint even when dealing with a large number of messages.
+- The application loads sources/sinks based on an importable name. This means that sources/sinks can be added simply by creating the appropriate class - no further code required.
+  - This also means that we can load external classes, allowing users of the application to load their own custom sources/sinks without forking the project and requiring them to be in the main project. This is already implemented and held behind a CLI flag.
+- The configuration file allows for multiple sources/sinks to be configured using the same class. That is to say you could configure many IMAP sources and many ElasticSearch sinks and have them all operate with their won config.
+- Configuration for sources/sinks are defined using pydantic and attached to classes using type annotations. This allows us to validate configuration before creating objects and for type checking/auto-completion during development.
+  - This is also why there is no application level changes to add a new source/sink to the application apart from creating the class.
+- Because the application is designed as a long lived process it can be managed through existing service/daemon tools such as systemd.

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,5 +1,8 @@
 # Elasticsearch and Kibana
 
+!!! warning
+    This documentation has not been reviewed for version `9.0.0`. Please consider submitting a pull request to update it.
+
 To set up visual dashboards of DMARC data, install Elasticsearch and Kibana.
 
 !!! note
@@ -128,7 +131,7 @@ server.ssl.key: /etc/kibana/kibana.key
     ```text
     elasticsearch.hosts: ['https://SERVER_IP:9200']
     ```
-    => 
+    =>
     ```text
     elasticsearch.hosts: ['https://127.0.0.1:9200']
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,31 +1,19 @@
 # Parsedmarc: Open source DMARC report analyzer and visualizer
 
-[![Build
-Status](https://github.com/domainaware/parsedmarc/actions/workflows/python-tests.yml/badge.svg)](https://github.com/domainaware/parsedmarc/actions/workflows/python-tests.yml)
-[![Code
-Coverage](https://codecov.io/gh/domainaware/parsedmarc/branch/master/graph/badge.svg)](https://codecov.io/gh/domainaware/parsedmarc)
-[![PyPI
-Package](https://img.shields.io/pypi/v/parsedmarc.svg)](https://pypi.org/project/parsedmarc/)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/parsedmarc?color=blue)](https://pypistats.org/packages/parsedmarc)
+[![Build Status](https://github.com/nhairs/parsedmarc-fork/actions/workflows/test-suite.yml/badge.svg)](https://github.com/nhairs/parsedmarc-fork/actions/workflows/test-suite.yml)
+<!-- [![PyPI Package](https://img.shields.io/pypi/v/parsedmarc.svg)](https://pypi.org/project/parsedmarc/) -->
+<!-- [![PyPI - Downloads](https://img.shields.io/pypi/dm/parsedmarc?color=blue)](https://pypistats.org/packages/parsedmarc) -->
 
-!!! danger
-    **This is not the [official parsedmarc documentation](https://domainaware.github.io/parsedmarc/index.html)**
-
-    **This is a [test branch](https://github.com/nhairs/parsedmarc/tree/docs) showcasing mkdocs**
-
-!!! example "Help Wanted"
-
-    This is a project is maintained by one developer.
-    Please consider reviewing the open [issues] to see how you can contribute code, documentation, or user support.
-    Assistance on the pinned issues would be particularly helpful.
-
-    Thanks to all [contributors]!
-
-`parsedmarc` is a Python module and CLI utility for parsing DMARC reports.
+ParseDMARC is a Python module and CLI utility for parsing DMARC reports.
 When used with Elasticsearch and Kibana (or Splunk), it works as a self-hosted
 open source alternative to commercial DMARC report processing services such
 as Agari Brand Protection, Dmarcian, OnDMARC, ProofPoint Email Fraud Defense,
 and Valimail.
+
+!!! danger "This is not the offical documentation"
+    **This is not the [official parsedmarc documentation](https://domainaware.github.io/parsedmarc/index.html)**
+
+    **This is an experimental fork utilising a new software architecture. See [GitHub #1](https://github.com/nhairs/parsedmarc-fork/issues/1) for details.**
 
 ![screenshot of DMARC summary charts in Kibana](static/screenshots/dmarc-summary-charts.png)
 
@@ -42,5 +30,35 @@ and Valimail.
   premade dashboards
 - Optionally send reports to Apache Kafka
 
-[contributors]: https://github.com/domainaware/parsedmarc/graphs/contributors
-[issues]: https://github.com/domainaware/parsedmarc/issues
+## Quick Start
+
+Follow our [Quickstart Guide](quickstart.md) (under contruction).
+
+```python title="TLDR"
+# TODO
+```
+
+### Migrating to Version `9.0.0`
+
+If you are using an older version of ParseDMARC, We have a handy [migration guide](migrating.md) available.
+
+## License
+
+This project is licensed under the [Apache License 2.0](https://github.com/nhairs/parsedmarc-fork/blob/main/LICENSE).
+
+## Bugs, Feature Requests etc
+Please [submit an issue on github](https://github.com/nhairs/parsedmarc-fork/issues).
+
+In the case of bug reports, please help us help you by following best practices [^1^](https://marker.io/blog/write-bug-report/) [^2^](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
+
+In the case of feature requests, please provide background to the problem you are trying to solve so that we can a solution that makes the most sense for the library as well as your use case.
+
+## Contributions are Weclome!
+
+Please check out our [Contributors Guide](contributing.md).
+
+## Authors and Maintainers
+
+This project is authored by [Sean Whalen](https://github.com/seanthegeek), [Nicholas Hairs](https://github.com/nhairs), and our wonderful [contributors](https://github.com/nhairs/python-json-logger/graphs/contributors).
+
+It is currently maintained by [Nicholas Hairs](https://github.com/nhairs) ([nicholashairs.com](https://www.nicholashairs.com)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,8 @@
 # Installation
 
+!!! warning
+    This documentation has not been reviewed for version `9.0.0`. Please consider submitting a pull request to update it.
+
 ## Prerequisites
 
 `parsedmarc` works with Python 3 only.

--- a/docs/kibana.md
+++ b/docs/kibana.md
@@ -1,5 +1,7 @@
-
 # Using the Kibana dashboards
+
+!!! warning
+    This documentation has not been reviewed for version `9.0.0`. Please consider submitting a pull request to update it.
 
 The Kibana DMARC dashboards are a human-friendly way to understand the
 results from incoming DMARC reports.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -28,6 +28,43 @@ For deeper information about configuring and running `parsedmarcd` see:
 - [Configuring ParseDMARC](configuration.md)
 - [Running ParseDMARC](running.md)
 
+### Migrating Existing CLI arguments
+
+`file_path`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+
+`--help`/`-h`: no changes.
+
+`--config-file`/`-c`: moved to `--config`. For more information see [Configure `parsedmarcd` below](#configuring-parsedmarc).
+
+`--strip-attachment-payloads`: not supported - use config `parser.strip_attachment_payloads` instead.
+
+`--output`/`-o`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+
+`--aggregate-json-filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+
+`--forensic-json-filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+
+`--aggregate-csv-filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+
+`--forensic-csv-filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+
+`--nameservers`/`-n`: not supported - use config `parser.nameservers` instead.
+
+`--dns-timeout`/`-t`: not supported - use config `parser.dns_timeout` instead.
+
+`--offline`: not supported - use config `parser.offline` instead.
+
+`--silent`/`-s`: not supported.
+
+`--verbose`: now supports using `-v` and up to 3 levels of verbosity (e.g. `-vvv`).
+
+`--debug`: not supported - use `--verbose`/`-v` instead.
+
+`--log-file`: not supported - use `--log-dir` instead.
+
+`--version`/`-v`: `--version` is unchanged. `-v` no longer prints the version - it instead is used for `--verbose`.
+
+
 ## Configuring `parsedmarcd`
 
 `parsedmarcd` uses YAML (or JSON) for configuration. This allows for much richer configuration but also requires migrating your old config to the new format.
@@ -69,7 +106,7 @@ Each source and sink is configured by giving it a unique name and then providing
 
 
 
-### Migrating Your Config
+## Migrating Your Config
 
 This section documents each item in the `parsedmarc` config and how to move it to the `parsedmarcd` config.
 
@@ -78,7 +115,7 @@ All heading are config options are defined using their original `parsedmarc` nam
 !!! warning "TODO"
     list all config items within each section, don't just say "use this".
 
-#### `general`
+### `general`
 
 `save_aggregate`: not supported - no comparable option.
 
@@ -113,7 +150,7 @@ All heading are config options are defined using their original `parsedmarc` nam
 `n_procs`: not supported - no comparable option.
 
 
-#### `mailbox`
+### `mailbox`
 
 Use a `.email:MailboxConnectionSource` Source.
 
@@ -132,7 +169,7 @@ Use a `.email:MailboxConnectionSource` Source.
 `check_timeout`: not supported - no comparable option.
 
 
-#### `imap`
+### `imap`
 
 Use a `.email:Imap` Source.
 
@@ -149,7 +186,7 @@ Use a `.email:Imap` Source.
 `password`: no changes.
 
 
-#### `msgraph`
+### `msgraph`
 
 Use a `.email.MicosoftGraph` Source.
 
@@ -172,7 +209,7 @@ Use a `.email.MicosoftGraph` Source.
 `allow_unencrypted_storage`: no changes.
 
 
-#### `elasticsearch`
+### `elasticsearch`
 
 Use a `.elasticsearch:Elasticsearch` Sink.
 
@@ -201,17 +238,17 @@ Use a `.elasticsearch:Elasticsearch` Sink.
 `number_of_replicas`: moved to `client.number_of_replicas`.
 
 
-#### `opensearch`
+### `opensearch`
 
 Not supported - [GitHub issue #6](https://github.com/nhairs/parsedmarc-fork/issues/6).
 
 
-#### `splunk_hec`
+### `splunk_hec`
 
 Not supported - [GitHub Issue #27](https://github.com/nhairs/parsedmarc-fork/issues/27).
 
 
-#### `kafka`
+### `kafka`
 
 Use a `.kafka:Kafka` Sink.
 
@@ -230,12 +267,12 @@ Use a `.kafka:Kafka` Sink.
 `forensic_topic`: moved to `forensic_report_topic`.
 
 
-#### `smtp`
+### `smtp`
 
 Not supported - [GitHub Issue #29](https://github.com/nhairs/parsedmarc-fork/issues/29).
 
 
-#### `s3`
+### `s3`
 
 Use a `.aws:S3` Sink.
 
@@ -252,7 +289,7 @@ Use a `.aws:S3` Sink.
 `secret_access_key`: moved to `client.aws_secret_access_key`.
 
 
-#### `syslog`
+### `syslog`
 
 Use a `.syslog:Syslog` Sink.
 
@@ -261,7 +298,7 @@ Use a `.syslog:Syslog` Sink.
 `port`: moved to `syslog_port`.
 
 
-#### `gmail_api`
+### `gmail_api`
 
 Use a `.email:Google` Source.
 
@@ -278,7 +315,7 @@ Use a `.email:Google` Source.
 `paginate_messages`: not supported - [GitHub Issue #14](https://github.com/nhairs/parsedmarc-fork/issues/14).
 
 
-#### `log_analytics`
+### `log_analytics`
 
 Use a `.azure:LogAnalytics` Sink.
 
@@ -299,12 +336,12 @@ Use a `.azure:LogAnalytics` Sink.
 `dcr_smtp_tls_stream`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
 
 
-#### `gelf`
+### `gelf`
 
 Not supported - [GitHub Issue #13](https://github.com/nhairs/parsedmarc-fork/issues/13).
 
 
-#### `webhook`
+### `webhook`
 
 Use a `.webhook:JsonWebhook` Sink.
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -115,125 +115,81 @@ All heading are config options are defined using their original `parsedmarc` nam
 
 ### `general`
 
-`save_aggregate`: not supported - no comparable option.
-
-`save_forensic`: not supported - no comparable option.
-
-`save_smtp_tls`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
-`strip_attachment_payloads`: moved to `parser.strip_attachment_payloads`
-
-`output`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
-`aggregate_json_filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
-
-`forensic_json_filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
-
-`ip_db_path`: moved to `parser.ip_db_path`
-
-`offline`: moved to `parser.offline`
-
-`always_use_local_files`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10).
-
-`local_reverse_dns_map_path`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10).
-
-`nameservers`: moved to `parser.nameservers.[]`
-
-`dns_timeout`: moved to `parse.dns_timeout`
-
-`debug`: not supported - use the `--verbose`/`-v` commandline option instead.
-
-`silent`: not supported - no comparable option.
-
-`log_file`: not supported - use the `--log-dir` commadline option instead.
-
-`n_procs`: not supported - no comparable option.
+- `save_aggregate`: not supported - no comparable option.
+- `save_forensic`: not supported - no comparable option.
+- `save_smtp_tls`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
+- `strip_attachment_payloads`: moved to `parser.strip_attachment_payloads`.
+- `output`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+- `aggregate_json_filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+- `forensic_json_filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
+- `ip_db_path`: moved to `parser.ip_db_path`
+- `offline`: moved to `parser.offline`.
+- `always_use_local_files`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10).
+- `local_reverse_dns_map_path`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10).
+- `nameservers`: moved to `parser.nameservers`.
+- `dns_timeout`: moved to `parse.dns_timeout`.
+- `debug`: not supported - use the `--verbose`/`-v` commandline option instead.
+- `silent`: not supported - no comparable option.
+- `log_file`: not supported - use the `--log-dir` commadline option instead.
+- `n_procs`: not supported - no comparable option.
 
 
 ### `mailbox`
 
 Use a `.email:MailboxConnectionSource` Source.
 
-`reports_folder`: no changes.
-
-`archive_folder`: no changes.
-
-`watch`: not supported - no comparable option.
-
-`delete`: not supported - use `mode: "delete"` instead.
-
-`test`: not supported - use `mode: "test"` instead.
-
-`batch_size`: not supported - no comparable option.
-
-`check_timeout`: not supported - no comparable option.
+- `reports_folder`: no changes.
+- `archive_folder`: no changes.
+- `watch`: not supported - no comparable option.
+- `delete`: not supported - use `mode: "delete"` instead.
+- `test`: not supported - use `mode: "test"` instead.
+- `batch_size`: not supported - no comparable option.
+- `check_timeout`: not supported - no comparable option.
 
 
 ### `imap`
 
 Use a `.email:Imap` Source.
 
-`host`: no changes.
-
-`port`: now optional and will select the appropriate default port based on SSL/TLS settings.
-
-`ssl`: no changes.
-
-`skip_certificate_verification`: moved to `verify_ssl`.
-
-`user`: moved to `username`
-
-`password`: no changes.
+- `host`: no changes.
+- `port`: now optional and will select the appropriate default port based on SSL/TLS settings.
+- `ssl`: no changes.
+- `skip_certificate_verification`: moved to `verify_ssl`.
+- `user`: moved to `username`.
+- `password`: no changes.
 
 
 ### `msgraph`
 
 Use a `.email.MicosoftGraph` Source.
 
-`auth_method`: no changes.
-
-`user`: moved to `username`.
-
-`password`: no changes.
-
-`client_id`: no changes.
-
-`client_secret`: no changes.
-
-`tenant_id`: no changes.
-
-`mailbox`: no changes.
-
-`token_file`: no changes.
-
-`allow_unencrypted_storage`: no changes.
+- `auth_method`: no changes.
+- `user`: moved to `username`.
+- `password`: no changes.
+- `client_id`: no changes.
+- `client_secret`: no changes.
+- `tenant_id`: no changes.
+- `mailbox`: no changes.
+- `token_file`: no changes.
+- `allow_unencrypted_storage`: no changes.
 
 
 ### `elasticsearch`
 
 Use a `.elasticsearch:Elasticsearch` Sink.
 
-`hosts`: moved to `client.hosts`.
-
-`user`: moved to `client.username`.
-
-`password`: moved to `client.password`.
-
-`apiKey`: moved to `client.api_key`.
-
-`ssl`: moved to `client.use_ssl`.
-
-`timeout`: moved to `client.timeout`.
-
-`cert_path`: moved to `client.ssl_cert_path`.
-
-`index_suffix`: moved to `client.index_suffix`.
-
-`index_prefix`: not supported - [GitHub Issue #12](https://github.com/nhairs/parsedmarc-fork/issues/12).
-
-`monthly_indexes`: moved to `client.monthly_indexes`.
-
-`number_of_shards`: moved to `client.number_of_shards`.
-
-`number_of_replicas`: moved to `client.number_of_replicas`.
+- `hosts`: moved to `client.hosts`.
+- `user`: moved to `client.username`.
+- `password`: moved to `client.password`.
+- `apiKey`: moved to `client.api_key`.
+- `ssl`: moved to `client.ssl`.
+- `timeout`: moved to `client.timeout`.
+- `cert_path`: moved to `client.cert_path`.
+- `index_suffix`: no changes.
+- `index_prefix`: not supported - [GitHub Issue #12](https://github.com/nhairs/parsedmarc-fork/issues/12).
+- `monthly_indexes`: no changes.
+- `number_of_shards`: no changes.
+- `number_of_replicas`: no changes.
 
 
 ### `opensearch`
@@ -250,19 +206,13 @@ Not supported - [GitHub Issue #27](https://github.com/nhairs/parsedmarc-fork/iss
 
 Use a `.kafka:Kafka` Sink.
 
-`hosts`: moved to `client.hosts`.
-
-`user`: moved to `client.username`.
-
-`password`: moved to `client.password`.
-
-`ssl`: moved to `client.ssl`.
-
-`skip_certificate_verification`: moved to `client.skip_certificate_verification`.
-
-`aggregate_topic`: moved to `aggregate_report_topic`.
-
-`forensic_topic`: moved to `forensic_report_topic`.
+- `hosts`: moved to `client.hosts`.
+- `user`: moved to `client.username`.
+- `password`: moved to `client.password`.
+- `ssl`: moved to `client.ssl`.
+- `skip_certificate_verification`: moved to `client.skip_certificate_verification`.
+- `aggregate_topic`: moved to `aggregate_report_topic`.
+- `forensic_topic`: moved to `forensic_report_topic`.
 
 
 ### `smtp`
@@ -274,64 +224,46 @@ Not supported - [GitHub Issue #29](https://github.com/nhairs/parsedmarc-fork/iss
 
 Use a `.aws:S3` Sink.
 
-`bucket`: no changes.
-
-`path`: moved to `path_prefix`.
-
-`region_name`: moved to `client.region_name`.
-
-`endpoint_url`: moved to `client.endpoint_url`.
-
-`access_key_id`: moved to `client.aws_access_key_id`.
-
-`secret_access_key`: moved to `client.aws_secret_access_key`.
+- `bucket`: no changes.
+- `path`: moved to `path_prefix`.
+- `region_name`: moved to `client.region_name`.
+- `endpoint_url`: moved to `client.endpoint_url`.
+- `access_key_id`: moved to `client.aws_access_key_id`.
+- `secret_access_key`: moved to `client.aws_secret_access_key`.
 
 
 ### `syslog`
 
 Use a `.syslog:Syslog` Sink.
 
-`server`: moved to `syslog_host`.
-
-`port`: moved to `syslog_port`.
+- `server`: moved to `syslog_host`.
+- `port`: moved to `syslog_port`.
 
 
 ### `gmail_api`
 
 Use a `.email:Google` Source.
 
-`credentials_file`: no changes.
-
-`token_file`: no changes.
-
-`include_spam_trash`: no changes.
-
-`scopes`: no changes.
-
-`oauth2_port`: no changes.
-
-`paginate_messages`: not supported - [GitHub Issue #14](https://github.com/nhairs/parsedmarc-fork/issues/14).
+- `credentials_file`: no changes.
+- `token_file`: no changes.
+- `include_spam_trash`: no changes.
+- `scopes`: no changes.
+- `oauth2_port`: no changes.
+- `paginate_messages`: not supported - [GitHub Issue #14](https://github.com/nhairs/parsedmarc-fork/issues/14).
 
 
 ### `log_analytics`
 
 Use a `.azure:LogAnalytics` Sink.
 
-`client_id`: no changes.
-
-`client_secret`: no changes.
-
-`tenant_id`: no changes.
-
-`dce`: moved to `data_collection_endpoint`.
-
-`dcr_immutable_id`: moved to `data_collection_rule_id`.
-
-`dcr_aggreate_stream`: moved to `aggregate_report_stream`.
-
-`dcr_forensic_stream`: moved to `forensic_report_stream`.
-
-`dcr_smtp_tls_stream`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
+- `client_id`: no changes.
+- `client_secret`: no changes.
+- `tenant_id`: no changes.
+- `dce`: moved to `data_collection_endpoint`.
+- `dcr_immutable_id`: moved to `data_collection_rule_id`.
+- `dcr_aggreate_stream`: moved to `aggregate_report_stream`.
+- `dcr_forensic_stream`: moved to `forensic_report_stream`.
+- `dcr_smtp_tls_stream`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
 
 
 ### `gelf`
@@ -343,10 +275,7 @@ Not supported - [GitHub Issue #13](https://github.com/nhairs/parsedmarc-fork/iss
 
 Use a `.webhook:JsonWebhook` Sink.
 
-`aggregate_url`: moved to `dmarc_aggregate_url`.
-
-`forensic_url`: moved to `dmarc_forensic_url`.
-
-`smtp_tls_url`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
-
-`timeout`: moved to `http_timeout`.
+- `aggregate_url`: moved to `aggregate_report_url`.
+- `forensic_url`: moved to `forensic_report_url`.
+- `smtp_tls_url`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
+- `timeout`: moved to `http_timeout`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -112,8 +112,6 @@ This section documents each item in the `parsedmarc` config and how to move it t
 
 All heading are config options are defined using their original `parsedmarc` name as they were in version `8.15.0`.
 
-!!! warning "TODO"
-    list all config items within each section, don't just say "use this".
 
 ### `general`
 
@@ -125,9 +123,9 @@ All heading are config options are defined using their original `parsedmarc` nam
 `strip_attachment_payloads`: moved to `parser.strip_attachment_payloads`
 
 `output`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
-`aggregate_json_filename`: not supported - see `output` above.
+`aggregate_json_filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
 
-`forensic_json_filename`: not supported - see `output` above.
+`forensic_json_filename`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
 
 `ip_db_path`: moved to `parser.ip_db_path`
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -84,10 +84,10 @@ All heading are config options are defined using their original `parsedmarc` nam
 
 `save_forensic`: not supported - no comparable option.
 
-`save_smtp_tls`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5)
+`save_smtp_tls`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
 `strip_attachment_payloads`: moved to `parser.strip_attachment_payloads`
 
-`output`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24)
+`output`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24).
 `aggregate_json_filename`: not supported - see `output` above.
 
 `forensic_json_filename`: not supported - see `output` above.
@@ -96,9 +96,9 @@ All heading are config options are defined using their original `parsedmarc` nam
 
 `offline`: moved to `parser.offline`
 
-`always_use_local_files`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10)
+`always_use_local_files`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10).
 
-`local_reverse_dns_map_path`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10)
+`local_reverse_dns_map_path`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10).
 
 `nameservers`: moved to `parser.nameservers.[]`
 
@@ -112,54 +112,206 @@ All heading are config options are defined using their original `parsedmarc` nam
 
 `n_procs`: not supported - no comparable option.
 
+
 #### `mailbox`
 
-Use the `.email:MailboxConnectionSource` Source.
+Use a `.email:MailboxConnectionSource` Source.
+
+`reports_folder`: no changes.
+
+`archive_folder`: no changes.
+
+`watch`: not supported - no comparable option.
+
+`delete`: not supported - use `mode: "delete"` instead.
+
+`test`: not supported - use `mode: "test"` instead.
+
+`batch_size`: not supported - no comparable option.
+
+`check_timeout`: not supported - no comparable option.
+
 
 #### `imap`
 
-Use the `.email:Imap` Source.
+Use a `.email:Imap` Source.
+
+`host`: no changes.
+
+`port`: now optional and will select the appropriate default port based on SSL/TLS settings.
+
+`ssl`: no changes.
+
+`skip_certificate_verification`: moved to `verify_ssl`.
+
+`user`: moved to `username`
+
+`password`: no changes.
+
 
 #### `msgraph`
 
-Use the `.email.MicosoftGraph` Source.
+Use a `.email.MicosoftGraph` Source.
+
+`auth_method`: no changes.
+
+`user`: moved to `username`.
+
+`password`: no changes.
+
+`client_id`: no changes.
+
+`client_secret`: no changes.
+
+`tenant_id`: no changes.
+
+`mailbox`: no changes.
+
+`token_file`: no changes.
+
+`allow_unencrypted_storage`: no changes.
+
 
 #### `elasticsearch`
 
-Use the `.elasticsearch:Elasticsearch` Sink.
+Use a `.elasticsearch:Elasticsearch` Sink.
+
+`hosts`: moved to `client.hosts`.
+
+`user`: moved to `client.username`.
+
+`password`: moved to `client.password`.
+
+`apiKey`: moved to `client.api_key`.
+
+`ssl`: moved to `client.use_ssl`.
+
+`timeout`: moved to `client.timeout`.
+
+`cert_path`: moved to `client.ssl_cert_path`.
+
+`index_suffix`: moved to `client.index_suffix`.
+
+`index_prefix`: not supported - [GitHub Issue #12](https://github.com/nhairs/parsedmarc-fork/issues/12).
+
+`monthly_indexes`: moved to `client.monthly_indexes`.
+
+`number_of_shards`: moved to `client.number_of_shards`.
+
+`number_of_replicas`: moved to `client.number_of_replicas`.
+
 
 #### `opensearch`
 
-Not supported - [GitHub issue #6](https://github.com/nhairs/parsedmarc-fork/issues/6)
+Not supported - [GitHub issue #6](https://github.com/nhairs/parsedmarc-fork/issues/6).
+
 
 #### `splunk_hec`
 
-Not supported - [GitHub Issue #27](https://github.com/nhairs/parsedmarc-fork/issues/27)
+Not supported - [GitHub Issue #27](https://github.com/nhairs/parsedmarc-fork/issues/27).
+
 
 #### `kafka`
 
-Use the `.kafka:Kafka` Sink.
+Use a `.kafka:Kafka` Sink.
+
+`hosts`: moved to `client.hosts`.
+
+`user`: moved to `client.username`.
+
+`password`: moved to `client.password`.
+
+`ssl`: moved to `client.ssl`.
+
+`skip_certificate_verification`: moved to `client.skip_certificate_verification`.
+
+`aggregate_topic`: moved to `aggregate_report_topic`.
+
+`forensic_topic`: moved to `forensic_report_topic`.
+
 
 #### `smtp`
 
-Not supported - [GitHub Issue #29](https://github.com/nhairs/parsedmarc-fork/issues/29)
+Not supported - [GitHub Issue #29](https://github.com/nhairs/parsedmarc-fork/issues/29).
+
 
 #### `s3`
 
-Use the `.aws:S3` Sink.
+Use a `.aws:S3` Sink.
+
+`bucket`: no changes.
+
+`path`: moved to `path_prefix`.
+
+`region_name`: moved to `client.region_name`.
+
+`endpoint_url`: moved to `client.endpoint_url`.
+
+`access_key_id`: moved to `client.aws_access_key_id`.
+
+`secret_access_key`: moved to `client.aws_secret_access_key`.
+
 
 #### `syslog`
 
-Use the `.syslog:Syslog` Sink.
+Use a `.syslog:Syslog` Sink.
+
+`server`: moved to `syslog_host`.
+
+`port`: moved to `syslog_port`.
+
 
 #### `gmail_api`
 
-Use the `.email:Google` Source.
+Use a `.email:Google` Source.
+
+`credentials_file`: no changes.
+
+`token_file`: no changes.
+
+`include_spam_trash`: no changes.
+
+`scopes`: no changes.
+
+`oauth2_port`: no changes.
+
+`paginate_messages`: not supported - [GitHub Issue #14](https://github.com/nhairs/parsedmarc-fork/issues/14).
+
 
 #### `log_analytics`
 
-Use the `.azure:LogAnalytics` Sink.
+Use a `.azure:LogAnalytics` Sink.
+
+`client_id`: no changes.
+
+`client_secret`: no changes.
+
+`tenant_id`: no changes.
+
+`dce`: moved to `data_collection_endpoint`.
+
+`dcr_immutable_id`: moved to `data_collection_rule_id`.
+
+`dcr_aggreate_stream`: moved to `aggregate_report_stream`.
+
+`dcr_forensic_stream`: moved to `forensic_report_stream`.
+
+`dcr_smtp_tls_stream`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
+
 
 #### `gelf`
 
-Not supported - [GitHub Issue #13](https://github.com/nhairs/parsedmarc-fork/issues/13)
+Not supported - [GitHub Issue #13](https://github.com/nhairs/parsedmarc-fork/issues/13).
+
+
+#### `webhook`
+
+Use a `.webhook:JsonWebhook` Sink.
+
+`aggregate_url`: moved to `dmarc_aggregate_url`.
+
+`forensic_url`: moved to `dmarc_forensic_url`.
+
+`smtp_tls_url`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5).
+
+`timeout`: moved to `http_timeout`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,165 @@
+# Migrating to `parsedmarcd`
+
+In version `9.0.0` (TBC) ParseDMARC introduced a new application for processing reports and although there are many benefit of this new application it is incompatible with the existing CLI application. To avoid confusion we will use the specific application name when talking about ParseDMARC:
+
+- `parsedmarc` is the original CLI application that you know and love.
+- `parsedmarcd` is the new application.
+
+## Application Architecture
+
+The primary difference between the two applications is in how they pass reports from some source to some destination.
+
+`parsedmarc` was designed to run on batches of reports with all reports being collected and processed from some source before being sent to some destination. This meant to process the continous stream of DMARC reports you'd have to either run `parsedmarc` on a timer (e.g. as a CRON job), or if you were collecting reports directly from an email mailbox run `parsedmarc` using `--watch` to check for new emails. This mode of operation did allow for reporting on all reports at once (e.g. as a CSV attachment to an email) as all reports were processed at the same time.
+
+In comparison `parsedmarcd` is designed to operate as a service on a stream of reports with reports being sent to the destinations as they come available. Once a report is processed, `parsedmarcd` will notifiy the source with the status (e.g. `SUCCESS`, `ERROR`) so that the source can take appropriate action (e.g. deleting the email on `SUCCESS`, or sending it to a dead-letter-queue on `ERROR`). This streaming model with feedback allows for more robust processing of reports and lower memory consumption.
+
+Another key difference is that in `parsedmarc` you could only provide one config for each type of section. This meant that if you wanted to have the same item configured multiple time (i.e. because you had multiple IMAP mailboxes to monitor), then you would have to run `parsedmarc` multiple times. With `parsedmarcd` items use a unique user-defined name allowing you to repeat the same type of item with different configuration.
+
+You can find the full details about the [new application architecture here](architecture.md).
+
+## Running `parsedmarcd`
+
+`parsedmarcd` is designed to run as a service and as such most configuration is done through configuration files. For the purposes of this guide know that you can run the application using `parsedmarcd --config /path/to/config.yml` and stop it using ++ctrl+c++.
+
+For deeper information about configuring and running `parsedmarcd` see:
+
+- [Quickstart](quickstart.md)
+- [Installing ParseDMARC](installing.md)
+- [Configuring ParseDMARC](configuration.md)
+- [Running ParseDMARC](running.md)
+
+## Configuring `parsedmarcd`
+
+`parsedmarcd` uses YAML (or JSON) for configuration. This allows for much richer configuration but also requires migrating your old config to the new format.
+
+At this point it important to make sure you understand some key terminology:
+
+- **Source**: something that collects or otherwise produces reports for processing.
+- **Sink**: something that receives parsed reports.
+
+!!! warning
+    Currently `parsedmarcd` only supports have one sink configured. This is a known drawback and will be changed in the future.
+
+```yaml title="example-config.yml"
+parser:
+  nameservers:
+    - 1.1.1.1
+    - 8.8.8.8
+
+sources:
+  aws-ses-dev:
+    class: .aws:SimpleEmailService
+    session:
+      profile_name: my-dev-profile
+    queue_name: my-dev-dmarc-receiving
+
+sinks:
+  elasticsearch:
+    class: .elasticsearch:Elasticsearch
+    client:
+      hosts: localhost:9200
+      username: elastic
+      password: SECRET
+```
+
+Each source and sink is configured by giving it a unique name and then providing its `class` and then any other required configuration.
+
+!!! tip
+    Because each source and sink is given a unique name you can define the same class multiple times.
+
+
+
+### Migrating Your Config
+
+This section documents each item in the `parsedmarc` config and how to move it to the `parsedmarcd` config.
+
+All heading are config options are defined using their original `parsedmarc` name as they were in version `8.15.0`.
+
+!!! warning "TODO"
+    list all config items within each section, don't just say "use this".
+
+#### `general`
+
+`save_aggregate`: not supported - no comparable option.
+
+`save_forensic`: not supported - no comparable option.
+
+`save_smtp_tls`: not supported - [GitHub Issue #5](https://github.com/nhairs/parsedmarc-fork/issues/5)
+`strip_attachment_payloads`: moved to `parser.strip_attachment_payloads`
+
+`output`: not supported - [GitHub Issue #24](https://github.com/nhairs/parsedmarc-fork/issues/24)
+`aggregate_json_filename`: not supported - see `output` above.
+
+`forensic_json_filename`: not supported - see `output` above.
+
+`ip_db_path`: moved to `parser.ip_db_path`
+
+`offline`: moved to `parser.offline`
+
+`always_use_local_files`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10)
+
+`local_reverse_dns_map_path`: not supported - [GitHub Issue #10](https://github.com/nhairs/parsedmarc-fork/issues/10)
+
+`nameservers`: moved to `parser.nameservers.[]`
+
+`dns_timeout`: moved to `parse.dns_timeout`
+
+`debug`: not supported - use the `--verbose`/`-v` commandline option instead.
+
+`silent`: not supported - no comparable option.
+
+`log_file`: not supported - use the `--log-dir` commadline option instead.
+
+`n_procs`: not supported - no comparable option.
+
+#### `mailbox`
+
+Use the `.email:MailboxConnectionSource` Source.
+
+#### `imap`
+
+Use the `.email:Imap` Source.
+
+#### `msgraph`
+
+Use the `.email.MicosoftGraph` Source.
+
+#### `elasticsearch`
+
+Use the `.elasticsearch:Elasticsearch` Sink.
+
+#### `opensearch`
+
+Not supported - [GitHub issue #6](https://github.com/nhairs/parsedmarc-fork/issues/6)
+
+#### `splunk_hec`
+
+Not supported - [GitHub Issue #27](https://github.com/nhairs/parsedmarc-fork/issues/27)
+
+#### `kafka`
+
+Use the `.kafka:Kafka` Sink.
+
+#### `smtp`
+
+Not supported - [GitHub Issue #29](https://github.com/nhairs/parsedmarc-fork/issues/29)
+
+#### `s3`
+
+Use the `.aws:S3` Sink.
+
+#### `syslog`
+
+Use the `.syslog:Syslog` Sink.
+
+#### `gmail_api`
+
+Use the `.email:Google` Source.
+
+#### `log_analytics`
+
+Use the `.azure:LogAnalytics` Sink.
+
+#### `gelf`
+
+Not supported - [GitHub Issue #13](https://github.com/nhairs/parsedmarc-fork/issues/13)

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,5 +1,8 @@
 # Sample outputs
 
+!!! warning
+    This documentation has not been reviewed for version `9.0.0`. Please consider submitting a pull request to update it.
+
 ## Sample aggregate report output
 
 Here are the results from parsing the [example](https://dmarc.org/wiki/FAQ#I_need_to_implement_aggregate_reports.2C_what_do_they_look_like.3F)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,3 @@
+# Quickstart Guide
+
+!!! example "Under Construction"

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-Security support for Python JSON Logger is provided for all [security supported versions of Python](https://endoflife.date/python) and for unsupported versions of Python where [recent downloads over the last 90 days exceeds 5% of all downloads](https://pypistats.org/packages/parsedmarc).
+Security support for ParseDMARC is provided for all [security supported versions of Python](https://endoflife.date/python) and for unsupported versions of Python where [recent downloads over the last 90 days exceeds 5% of all downloads](https://pypistats.org/packages/parsedmarc).
 
 
-As of 2024-09-07 security support is provided for Python versions `3.8+`.
+As of 2024-10-12 security support is provided for Python versions `3.8+`.
 
 
 ## Reporting a Vulnerability

--- a/docs/splunk.md
+++ b/docs/splunk.md
@@ -1,5 +1,8 @@
 # Splunk
 
+!!! warning
+    This documentation has not been reviewed for version `9.0.0`. Please consider submitting a pull request to update it.
+
 Starting in version 4.3.0 `parsedmarc` supports sending aggregate and/or
 forensic DMARC data to a Splunk [HTTP Event collector (HEC)].
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,8 @@
 # Using parsedmarc
 
+!!! warning
+    This documentation has not been reviewed for version `9.0.0`. Please consider submitting a pull request to update it.
+
 ## CLI help
 
 ```text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: "ParseDMARC Fork"
 site_url: https://nhairs.github.io/parsedmarc-fork
 repo_url: https://github.com/nhairs/parsedmarc-fork
 edit_uri: tree/main/docs
-copyright: "Copyright &copy; Parsedmarc Contributors</a>"
+copyright: "Copyright &copy; ParseDMARC Fork Contributors</a>"
 watch:
   - mkdocs.yml
   - README.md
@@ -11,19 +11,24 @@ watch:
 
 nav:
   - "Home": index.md
-  - installation.md
-  - usage.md
-  - output.md
-  - elasticsearch.md
-  - kibana.md
-  - splunk.md
-  - davmail.md
-  - migrating.md
-  - contributing.md
-  # - changelog.md
-  - DMARC:
+  - quickstart.md
+  - Guide:
+    - installation.md
+    - usage.md
+    - output.md
+    - elasticsearch.md
+    - kibana.md
+    - splunk.md
+    - davmail.md
+    - migrating.md
+  - About DMARC:
     - dmarc.md
     - mailing-lists.md
+  - security.md
+  - Development:
+    - contributing.md
+    - architecture.md
+  # - changelog.md
   - API Reference: reference/
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - kibana.md
   - splunk.md
   - davmail.md
+  - migrating.md
   - contributing.md
   # - changelog.md
   - DMARC:
@@ -76,6 +77,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.details
   - pymdownx.caret
+  - pymdownx.keys
 
 plugins:
   - autorefs

--- a/src/parsedmarc/sink/elasticsearch.py
+++ b/src/parsedmarc/sink/elasticsearch.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 # Standard Library
-from typing import Any, Dict, Literal
+from typing import List, Literal
+
+# Installed
+from pydantic import BaseModel
 
 # Local
 from ..const import AppState
@@ -29,7 +32,7 @@ class Elasticsearch(Sink):
         self._state = AppState.SETTING_UP
 
         try:
-            self.client = ElasticsearchClient(**self.config.client)
+            self.client = ElasticsearchClient(**dict(self.config.client))
             self.client.migrate_indexes()
 
         except:
@@ -68,6 +71,19 @@ class Elasticsearch(Sink):
 class ElasticsearchConfig(BaseConfig):
     """Elasticsearch Config"""
 
-    # As per https://elasticsearch-py.readthedocs.io/en/v8.13.0/api/elasticsearch.html
-    client: Dict[str, Any]
+    client: ElasticsearchClientConfig
     on_duplicate: Literal["discard"] = "discard"  # TODO: implement update logic and add
+
+
+class ElasticsearchClientConfig(BaseModel):
+    hosts: str | List[str]
+    use_ssl: bool = False
+    ssl_cert_path: str | None = None
+    username: str | None = None
+    password: str | None = None
+    api_key: str | None = None
+    timeout: float = 60.0
+    index_suffix: str | None = None
+    monthly_index: bool = True
+    number_of_shards: int = 1
+    number_of_replicas: int = 0

--- a/src/parsedmarc/sink/elasticsearch.py
+++ b/src/parsedmarc/sink/elasticsearch.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 # Standard Library
-from typing import List, Literal
+from typing import List, Literal, Union
 
 # Installed
 from pydantic import BaseModel
@@ -76,14 +76,14 @@ class ElasticsearchConfig(BaseConfig):
 
 
 class ElasticsearchClientConfig(BaseModel):
-    hosts: str | List[str]
+    hosts: Union[str, List[str]]
     use_ssl: bool = False
-    ssl_cert_path: str | None = None
-    username: str | None = None
-    password: str | None = None
-    api_key: str | None = None
+    ssl_cert_path: Union[str, None] = None
+    username: Union[str, None] = None
+    password: Union[str, None] = None
+    api_key: Union[str, None] = None
     timeout: float = 60.0
-    index_suffix: str | None = None
+    index_suffix: Union[str, None] = None
     monthly_index: bool = True
     number_of_shards: int = 1
     number_of_replicas: int = 0

--- a/src/parsedmarc/sink/elasticsearch.py
+++ b/src/parsedmarc/sink/elasticsearch.py
@@ -32,7 +32,19 @@ class Elasticsearch(Sink):
         self._state = AppState.SETTING_UP
 
         try:
-            self.client = ElasticsearchClient(**dict(self.config.client))
+            self.client = ElasticsearchClient(
+                hosts=self.config.client.hosts,
+                use_ssl=self.config.client.ssl,
+                ssl_cert_path=self.config.client.cert_path,
+                username=self.config.client.username,
+                password=self.config.client.password,
+                api_key=self.config.client.api_key,
+                timeout=self.config.client.timeout,
+                index_suffix=self.config.index_suffix,
+                monthly_indexes=self.config.monthly_indexes,
+                number_of_shards=self.config.number_of_shards,
+                number_of_replicas=self.config.number_of_replicas,
+            )
             self.client.migrate_indexes()
 
         except:
@@ -72,18 +84,20 @@ class ElasticsearchConfig(BaseConfig):
     """Elasticsearch Config"""
 
     client: ElasticsearchClientConfig
+    index_suffix: Union[str, None] = None
+    monthly_indexes: bool = True
+    number_of_shards: int = 1
+    number_of_replicas: int = 0
     on_duplicate: Literal["discard"] = "discard"  # TODO: implement update logic and add
 
 
 class ElasticsearchClientConfig(BaseModel):
+    """Elasticsearch Client Config"""
+
     hosts: Union[str, List[str]]
-    use_ssl: bool = False
-    ssl_cert_path: Union[str, None] = None
+    ssl: bool = False
+    cert_path: Union[str, None] = None
     username: Union[str, None] = None
     password: Union[str, None] = None
     api_key: Union[str, None] = None
     timeout: float = 60.0
-    index_suffix: Union[str, None] = None
-    monthly_index: bool = True
-    number_of_shards: int = 1
-    number_of_replicas: int = 0

--- a/src/parsedmarc/sink/webhook.py
+++ b/src/parsedmarc/sink/webhook.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 # Standard Library
-from typing import Dict
+from typing import Dict, Union
 
 # Installed
 import requests
@@ -68,7 +68,7 @@ class JsonWebhook(Sink):
 class JsonWebhookConfig(BaseConfig):
     """JsonWebhook Config"""
 
-    http_headers: Dict[str, str] | None = None
+    http_headers: Union[Dict[str, str], None] = None
     http_timeout: int = 60
 
     # URLs

--- a/src/parsedmarc/sink/webhook.py
+++ b/src/parsedmarc/sink/webhook.py
@@ -52,11 +52,11 @@ class JsonWebhook(Sink):
         return
 
     def process_aggregate_report(self, report: AggregateReport) -> None:
-        self.send_report(report.data, self.config.dmarc_aggregate_url)
+        self.send_report(report.data, self.config.aggregate_report_url)
         return
 
     def process_forensic_report(self, report: ForensicReport) -> None:
-        self.send_report(report.data, self.config.dmarc_forensic_url)
+        self.send_report(report.data, self.config.forensic_report_url)
         return
 
     def send_report(self, report: dict, url: str) -> None:
@@ -72,5 +72,5 @@ class JsonWebhookConfig(BaseConfig):
     http_timeout: int = 60
 
     # URLs
-    dmarc_aggregate_url: str
-    dmarc_forensic_url: str
+    aggregate_report_url: str
+    forensic_report_url: str

--- a/tests/test_source_sink_config.py
+++ b/tests/test_source_sink_config.py
@@ -96,7 +96,7 @@ def test_source_init(class_: Type[Source], config: Dict[str, Any]):
     "class_, config",
     [
         # ElasticSearch
-        (parsedmarc.sink.elasticsearch.Elasticsearch, {"client": {"foo": "bar"}}),
+        (parsedmarc.sink.elasticsearch.Elasticsearch, {"client": {"hosts": "foo"}}),
         # Util
         (parsedmarc.sink.util.Noop, {}),
         (parsedmarc.sink.util.Console, {}),

--- a/tests/test_source_sink_config.py
+++ b/tests/test_source_sink_config.py
@@ -14,6 +14,7 @@ from parsedmarc.parser import ReportParser
 from parsedmarc.sink.base import Sink
 import parsedmarc.sink.elasticsearch
 import parsedmarc.sink.util
+import parsedmarc.sink.webhook
 import parsedmarc.source.aws
 from parsedmarc.source.base import Source
 import parsedmarc.source.email
@@ -100,6 +101,11 @@ def test_source_init(class_: Type[Source], config: Dict[str, Any]):
         # Util
         (parsedmarc.sink.util.Noop, {}),
         (parsedmarc.sink.util.Console, {}),
+        # Webhook
+        (
+            parsedmarc.sink.webhook.JsonWebhook,
+            {"aggregate_report_url": "foo", "forensic_report_url": "bar"},
+        ),
     ],
 )
 def test_sink_init(class_: Type[Sink], config: Dict[str, Any]):


### PR DESCRIPTION
Fixes: #21 

Changes:

- Adds numerous new documentation pages
- Regroups documentation
- Adds warning to possibly updated documentation
- Minor README fixes
- Change `sink.elasticsearch.Elasticsearch` config to be more defined
- Change `sink.webhook.JsonWebhook` config to be aligned with other similar config
- Add `sink.webhook.JsonWebhook` to the tests