### PR TITLE
[parser] Don't fail on empty auth_results elements

### DIFF
--- a/src/parsedmarc/parser.py
+++ b/src/parsedmarc/parser.py
@@ -486,7 +486,8 @@ class ReportParser:
         else:
             lowered_from = ""
         new_record["identifiers"]["header_from"] = lowered_from
-        if record["auth_results"] is not None:
+
+        if isinstance(record["auth_results"], dict):
             auth_results = record["auth_results"].copy()
             if "spf" not in auth_results:
                 auth_results["spf"] = []


### PR DESCRIPTION
Fixes: #41

Empty `auth_results` elements are parsed as strings, as such we ignore any parsing result that isn't a `dict`.